### PR TITLE
I2C_ErrorResetCycle in error.c

### DIFF
--- a/projects/base-library/project/Core/Inc/error.h
+++ b/projects/base-library/project/Core/Inc/error.h
@@ -6,7 +6,6 @@
  *  Created on: Mar 30, 2024
  *  Author: Moiz
  */
-
 #ifndef INC_ERROR_H_
 #define INC_ERROR_H_
 
@@ -41,6 +40,7 @@ uint8_t index;
 static void reportError(errcode err_code, errlevel err_level); // Sending all accumulated error codes through UART and/or through CAN
 static void logError(errcode err_code); // Add error to error logs. Can be stored in memory
 static void ledIndicationError(ledpattern pattern);
+static void I2C_ErrorResetCycle(I2C_HandleTypeDef handle, uint16_t device_address, uint8_t register_address, uint8_t buffer);
 
 //-- Public Functions
 #define REPORT_ERR(err_code, err_level) (reportError(err_code, err_level))

--- a/projects/base-library/project/Core/Inc/error.h
+++ b/projects/base-library/project/Core/Inc/error.h
@@ -6,6 +6,8 @@
  *  Created on: Mar 30, 2024
  *  Author: Moiz
  */
+#include <cstdint>
+
 #ifndef INC_ERROR_H_
 #define INC_ERROR_H_
 
@@ -40,7 +42,7 @@ uint8_t index;
 static void reportError(errcode err_code, errlevel err_level); // Sending all accumulated error codes through UART and/or through CAN
 static void logError(errcode err_code); // Add error to error logs. Can be stored in memory
 static void ledIndicationError(ledpattern pattern);
-static void I2C_ErrorResetCycle(I2C_HandleTypeDef handle, uint16_t device_address, uint8_t register_address, uint8_t buffer);
+static void I2C_ErrorResetCycle(I2C_HandleTypeDef handle, uint16_t device_address, uint8_t register_address, int read_regs);
 
 //-- Public Functions
 #define REPORT_ERR(err_code, err_level) (reportError(err_code, err_level))

--- a/projects/base-library/project/Core/Src/error.c
+++ b/projects/base-library/project/Core/Src/error.c
@@ -8,8 +8,20 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
+#include "error.h"
+#include "board.h"
 
 /* Variables ------------------------------------------------------------------*/
 
 /* Functions ------------------------------------------------------------------*/
-
+static void I2C_ErrorResetCycle (I2C_HandleTypeDef handle, uint16_t device_address, uint8_t register_address, uint8_t buffer)  {
+    buffer[0] = register_address;
+	if (HAL_I2C_Master_Transmit(&handle, (device_address << 1), buffer, 1, HAL_MAX_DELAY) != HAL_OK) {
+		NVIC_SystemReset();
+	} else {
+        if (HAL_I2C_Master_Receive(&handle, (device_address << 1), buffer, 2, HAL_MAX_DELAY) != HAL_OK) {
+            NVIC_SystemReset();
+        }
+    }
+    HAL_Delay(250);
+}

--- a/projects/base-library/project/Core/Src/error.c
+++ b/projects/base-library/project/Core/Src/error.c
@@ -14,12 +14,13 @@
 /* Variables ------------------------------------------------------------------*/
 
 /* Functions ------------------------------------------------------------------*/
-static void I2C_ErrorResetCycle (I2C_HandleTypeDef handle, uint16_t device_address, uint8_t register_address, uint8_t buffer)  {
+static void I2C_ErrorResetCycle (I2C_HandleTypeDef handle, uint16_t device_address, uint8_t register_address, int read_regs)  {
+    uint8_t buffer;
     buffer[0] = register_address;
 	if (HAL_I2C_Master_Transmit(&handle, (device_address << 1), buffer, 1, HAL_MAX_DELAY) != HAL_OK) {
 		NVIC_SystemReset();
 	} else {
-        if (HAL_I2C_Master_Receive(&handle, (device_address << 1), buffer, 2, HAL_MAX_DELAY) != HAL_OK) {
+        if (HAL_I2C_Master_Receive(&handle, (device_address << 1), buffer, read_regs, HAL_MAX_DELAY) != HAL_OK) {
             NVIC_SystemReset();
         }
     }


### PR DESCRIPTION
Resets board in case of !HAL_OK via 12C (a pin specific reset is not possible with HAL). Doesn't wipe out previous data.


