### PR TITLE
Enforce consistent line endings in files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Normalize common STM32 sources to LF
+*.c     text eol=lf
+*.h     text eol=lf
+*.cpp   text eol=lf
+*.hpp   text eol=lf
+*.ld    text eol=lf
+*.s     text eol=lf
+*.S     text eol=lf
+*.ioc   text eol=lf
+*.txt   text eol=lf
+*.md    text eol=lf
+# Project/Eclipse/CubeMX metadata that’s actually text
+*.project    text eol=lf
+*.cproject   text eol=lf
+*.mxproject  text eol=lf
+*.launch     text eol=lf
+*.properties text eol=lf
+


### PR DESCRIPTION
# Reason for PR
Having different line endings means that git diffs EASILY reach into the hundreds of thousands of lines.

# Change(s)
All line endings will now be normalized to the UNIX standard of \lf

## Benefit(s)
- Git diffs are MUCH smaller
- Fewer merge conflicts

## Downsides(s)
- Potential for large git diffs during renormalization

