### PR TITLE
Stop sending CAN frames meant to be sent from another module

### DIFF
--- a/firmware/drv-modules/nmea0183/WIND_SENSOR.c
+++ b/firmware/drv-modules/nmea0183/WIND_SENSOR.c
@@ -29,7 +29,6 @@ static const uint8_t WIND_STATUS_INDEX = 5;
 
 // CAN communication
 static const can_frame_id_t SAIL_WIND_ID = 0x040;
-static const can_frame_id_t DATA_WIND_ID = 0x041;
 static const uint32_t WIND_DATA_LENGTH = FDCAN_DLC_BYTES_4;
 
 /*
@@ -253,7 +252,7 @@ void WIND_SENSOR__print(const WIND_SENSOR *self) {
 }
 
 /**
- *  Transmit SAIL_WIND or DATA_WIND over CANFD
+ *  Transmit SAIL_WIND over CANFD.
  */
 static HAL_StatusTypeDef
 WIND_SENSOR__CAN_transmit_single(WIND_SENSOR *self, can_frame_id_t CAN_ID,
@@ -285,7 +284,7 @@ WIND_SENSOR__CAN_transmit_single(WIND_SENSOR *self, can_frame_id_t CAN_ID,
 }
 
 /**
- *  Transmit both SAIL_WIND and DATA_WIND over CANFD
+ *  Transmit SAIL_WIND over CANFD
  *  as defined in [Sailbot's Confluence Page]
  *  (https://ubcsailbot.atlassian.net/wiki/spaces/prjt22/pages/1827176527/CAN+Frames)
  *
@@ -300,15 +299,5 @@ HAL_StatusTypeDef WIND_SENSOR__CAN_transmit(WIND_SENSOR *self,
     return HAL_ERROR;
   }
 
-  HAL_StatusTypeDef sailTransmitted =
-      WIND_SENSOR__CAN_transmit_single(self, SAIL_WIND_ID, hfdcan1);
-  HAL_StatusTypeDef dataTransmitted =
-      WIND_SENSOR__CAN_transmit_single(self, DATA_WIND_ID, hfdcan1);
-
-  NMEA_DEBUG_PRINT("[WIND][CAN] combined status sail=%d data=%d\r\n",
-                   sailTransmitted, dataTransmitted);
-
-  if (sailTransmitted != HAL_OK)
-    return sailTransmitted;
-  return dataTransmitted;
+  return WIND_SENSOR__CAN_transmit_single(self, SAIL_WIND_ID, hfdcan1);
 }

--- a/firmware/drv-modules/nmea0183/WIND_SENSOR.h
+++ b/firmware/drv-modules/nmea0183/WIND_SENSOR.h
@@ -99,7 +99,7 @@ bool WIND_SENSOR__parseMessage(WIND_SENSOR *self, NMEA0183Raw *message);
 void WIND_SENSOR__print(const WIND_SENSOR *self);
 
 /**
- *  Transmit both SAIL_WIND and DATA_WIND over CANFD
+ *  Transmit SAIL_WIND over CANFD
  *  as defined in [Sailbot's Confluence Page]
  *  (https://ubcsailbot.atlassian.net/wiki/spaces/prjt22/pages/1827176527/CAN+Frames)
  *

--- a/firmware/tests/drv-modules/nmea0183/wind_sensor_test.c
+++ b/firmware/tests/drv-modules/nmea0183/wind_sensor_test.c
@@ -241,7 +241,7 @@ static void test_wind_sensor_print_format(void) {
 }
 
 /**
- * @brief Validate CAN transmit packs wind payload and IDs.
+ * @brief Validate CAN transmit packs the SAIL_WIND payload and ID.
  *
  * @param void
  * @return void
@@ -258,19 +258,12 @@ static void test_wind_sensor_can_transmit_payload(void) {
 
   TEST_ASSERT(&g_failures,
               WIND_SENSOR__CAN_transmit(&sensor, &hfdcan) == HAL_OK);
-  TEST_ASSERT(&g_failures, g_tx_call_count == 2);
+  TEST_ASSERT(&g_failures, g_tx_call_count == 1);
   TEST_ASSERT(&g_failures, g_tx_identifiers[0] == 0x040);
-  TEST_ASSERT(&g_failures, g_tx_identifiers[1] == 0x041);
   TEST_ASSERT(&g_failures, g_tx_id_types[0] == FDCAN_STANDARD_ID);
-  TEST_ASSERT(&g_failures, g_tx_id_types[1] == FDCAN_STANDARD_ID);
   TEST_ASSERT(&g_failures, g_tx_data_lengths[0] == FDCAN_DLC_BYTES_4);
-  TEST_ASSERT(&g_failures, g_tx_data_lengths[1] == FDCAN_DLC_BYTES_4);
   TEST_ASSERT(&g_failures, g_tx_payload_sizes[0] == 4);
-  TEST_ASSERT(&g_failures, g_tx_payload_sizes[1] == 4);
-  TEST_ASSERT(&g_failures,
-              memcmp(g_tx_payloads[0], expected_payload, 4) == 0);
-  TEST_ASSERT(&g_failures,
-              memcmp(g_tx_payloads[1], expected_payload, 4) == 0);
+  TEST_ASSERT(&g_failures, memcmp(g_tx_payloads[0], expected_payload, 4) == 0);
 }
 
 /**
@@ -284,13 +277,12 @@ static void test_wind_sensor_can_transmit_propagates_status(void) {
   FDCAN_HandleTypeDef hfdcan = {0};
 
   reset_can_tx_capture();
-  g_tx_statuses[0] = HAL_OK;
-  g_tx_statuses[1] = HAL_ERROR;
-  g_tx_status_count = 2;
+  g_tx_statuses[0] = HAL_ERROR;
+  g_tx_status_count = 1;
 
   TEST_ASSERT(&g_failures,
               WIND_SENSOR__CAN_transmit(&sensor, &hfdcan) == HAL_ERROR);
-  TEST_ASSERT(&g_failures, g_tx_call_count == 2);
+  TEST_ASSERT(&g_failures, g_tx_call_count == 1);
 }
 
 /**


### PR DESCRIPTION
Stop sending 0x041 from the wingsail module, and only send 0x040 as intended
