### PR TITLE
fix: only transmit 0x040 SAIL_WIND on MWV sentences, not XDR

### DIFF
--- a/firmware/drv-modules/nmea0183/NMEA0183_scheduler.c
+++ b/firmware/drv-modules/nmea0183/NMEA0183_scheduler.c
@@ -58,7 +58,7 @@ bool NMEA0183__scheduler_step(NMEA0183_Scheduler *scheduler, uint32_t now_ms) {
     } else if (sentence_type == MESSAGE_MWV || sentence_type == MESSAGE_XDR) {
       if (scheduler->wind_sensor && scheduler->hfdcan1) {
         parsed = WIND_SENSOR__parseMessage(scheduler->wind_sensor, message);
-        if (parsed) {
+        if (parsed && sentence_type == MESSAGE_MWV) {
           HAL_StatusTypeDef status = WIND_SENSOR__CAN_transmit(
               scheduler->wind_sensor, scheduler->hfdcan1);
           if (status == HAL_OK) {


### PR DESCRIPTION
# Summary
- The CV7 wind sensor sends MWV (wind angle/speed) and XDR (temperature) as a back-to-back pair each cycle
- The scheduler was calling `WIND_SENSOR__CAN_transmit` for both sentence types, causing `0x040` to be sent twice per cycle
- The XDR-triggered transmission sent stale wind data, since XDR only updates `self->temp` — a field not present in `0x040` per the CAN frame spec
- Fix: guard the `CAN_transmit` call so it only fires when the parsed sentence was `MESSAGE_MWV`